### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,15 +14,15 @@ about: Create a report to help us improve
 2. <!-- Second Step -->
 3. <!-- and so on… -->
 
-**Expected behavior:**
+### Expected behavior:
 
 <!-- What you expect to happen -->
 
-**Actual behavior:**
+### Actual behavior:
 
 <!-- What actually happens -->
 
-**Reproduces how often:**
+### Reproduces how often:
 
 <!-- What percentage of the time does it reproduce? -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+### Description
+
+<!-- Description of the issue -->
+
+### Steps to Reproduce
+
+1. <!-- First Step -->
+2. <!-- Second Step -->
+3. <!-- and so on… -->
+
+**Expected behavior:**
+
+<!-- What you expect to happen -->
+
+**Actual behavior:**
+
+<!-- What actually happens -->
+
+**Reproduces how often:**
+
+<!-- What percentage of the time does it reproduce? -->
+
+### Additional Information
+
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+## Summary
+
+<!-- One paragraph explanation of the feature. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Acceptance Criteria
+
+<!-- A checklist of things a future PR should solve to be considerd "complete" -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,4 +14,6 @@ about: Suggest an idea for this project
 
 ## Acceptance Criteria
 
-<!-- A checklist of things a future PR should solve to be considerd "complete" -->
+<!-- A checklist of things a future PR should solve to be considered "complete" -->
+
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE/add_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_feature.md
@@ -1,0 +1,27 @@
+Resolves #<!-- Link to the issue describing the bug that you're fixing. If an issue does not exist, create one. -->
+
+### Description
+
+<!-- A description of the code changes -->
+
+### Acceptance Criteria
+
+<!-- A checklist of things a this PR changes and can be confirmed through testing -->
+
+ - [ ] 
+
+### Testing
+
+<!-- Steps a reviewer should take to confirm the above acceptance criteria -->
+
+1. <!-- First Step -->
+2. <!-- Second Step -->
+3. <!-- and so on… -->
+
+### Additional Notes
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,21 @@
+Resolves #<!-- Link to the issue describing the bug that you're fixing. If an issue does not exist, create one. -->
+
+### Description
+
+<!-- A description of the design of the bug fix -->
+
+### Steps to Verify Fix
+
+<!-- Steps a reviewer should take to confirm the bug is indeed fixed -->
+
+1. <!-- First Step -->
+2. <!-- Second Step -->
+3. <!-- and so on… -->
+
+### Additional Notes
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->


### PR DESCRIPTION
### Description

In our effort to create a contribution guide (#2), this PR creates template to guide users who are interested in submitting an issue or a pull request. After this PR is merged, [this guide](https://help.github.com/en/articles/creating-issue-templates-for-your-repository) can be followed to set up the templates in this repo.