### PR TITLE
Add daily emoji reporting to public channel

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,9 @@ def send_emoji_message(web_client: slack.WebClient, channel: str, emoji_name: st
 
     web_client.chat_postMessage(**message)
 
+    message.update({'channel': 'emoji_meta', 'post_at': emoji_message.next_release_date()})
+    web_client.chat_scheduleMessage(**message)
+
 
 if __name__ == '__main__':
     SLACK_TOKEN = os.environ['SLACK_BOT_TOKEN']

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from emoji_message import EmojiMessage
 
 
 @slack.RTMClient.run_on(event='emoji_changed')
-def emoji_callback(**payload):
+def emoji_callback(**payload) -> None:
     """Catch emoji_changed event.
 
     Triggered when an emoji is added, removed, or when a new alias has been created.
@@ -19,7 +19,7 @@ def emoji_callback(**payload):
     send_emoji_message(web_client, 'admin', emoji_name, event_type)
 
 
-def send_emoji_message(web_client: slack.WebClient, channel: str, emoji_name: str, event_type: str):
+def send_emoji_message(web_client: slack.WebClient, channel: str, emoji_name: str, event_type: str) -> None:
     """Send a message to a channel about an emoji event.
 
     :param web_client: The client to respond on
@@ -32,7 +32,9 @@ def send_emoji_message(web_client: slack.WebClient, channel: str, emoji_name: st
 
     web_client.chat_postMessage(**message)
 
-    message.update({'channel': 'emoji_meta', 'post_at': emoji_message.next_release_date()})
+    message.update({'channel': 'emoji_meta',
+                    'post_at': emoji_message.next_release_date(),
+                    'text': message.get('blocks')[0].get('text').get('text')})
     web_client.chat_scheduleMessage(**message)
 
 

--- a/app.py
+++ b/app.py
@@ -32,9 +32,7 @@ def send_emoji_message(web_client: slack.WebClient, channel: str, emoji_name: st
 
     web_client.chat_postMessage(**message)
 
-    message.update({'channel': 'emoji_meta',
-                    'post_at': emoji_message.next_release_date(),
-                    'text': message.get('blocks')[0].get('text').get('text')})
+    message.update({'channel': 'emoji_meta', 'post_at': emoji_message.next_release_date()})
     web_client.chat_scheduleMessage(**message)
 
 

--- a/emoji_message.py
+++ b/emoji_message.py
@@ -22,7 +22,7 @@ class EmojiMessage:
         self.event_type = event_type
         self.timestamp = ''
 
-    def get_message_payload(self):
+    def get_message_payload(self) -> dict:
         """Format and returns information to post slack message.
 
         :return: Formatted information for slack
@@ -32,28 +32,22 @@ class EmojiMessage:
             'channel': self.channel,
             'username': self.username,
             'icon_emoji': self.icon_emoji,
-            'blocks': [self._get_message_block()],
+            'text': self._get_message_text(),
         }
 
-    def _get_past_tense_event(self):
+    def _get_past_tense_event(self) -> str:
         """Format the event type into past tense.
 
         :return: Past tense event type
         """
         return f'{self.event_type}d' if self.event_type[-1] == 'e' else f'{self.event_type}ed'
 
-    def _get_message_block(self):
-        """Create and returns formatted message block to send.
+    def _get_message_text(self) -> str:
+        """Create and returns formatted message text to send.
 
-        :return: Formatted message block
+        :return: Formatted message text
         """
-        return {
-            'type': 'section',
-            'text': {
-                'type': 'mrkdwn',
-                'text': f':{self.icon_emoji}:  ({self.icon_emoji}) has been {self._get_past_tense_event()}',
-            },
-        }
+        return f':{self.icon_emoji}:  ({self.icon_emoji}) has been {self._get_past_tense_event()}'
 
     @staticmethod
     def next_release_date(release_hour: int = 3) -> str:

--- a/emoji_message.py
+++ b/emoji_message.py
@@ -1,5 +1,7 @@
 """Constructs emoji report message."""
 
+import datetime
+
 
 class EmojiMessage:
     """Constructs emoji report message."""
@@ -52,3 +54,13 @@ class EmojiMessage:
                 'text': f':{self.icon_emoji}:  ({self.icon_emoji}) has been {self._get_past_tense_event()}',
             },
         }
+
+
+    @staticmethod
+    def next_release_date() -> str:
+        """Get release time as Unix EPOCH timestamp"""
+        utc_time = datetime.datetime.utcnow()
+        days = 1 if utc_time.hour >= 3 else 0
+        offset_time = utc_time + datetime.timedelta(days=days)
+        send_timestamp = offset_time.replace(hour=3, minute=0, second=0, microsecond=0, tzinfo=datetime.timezone.utc).timestamp()
+        return str(send_timestamp)

--- a/emoji_message.py
+++ b/emoji_message.py
@@ -55,12 +55,12 @@ class EmojiMessage:
             },
         }
 
-
     @staticmethod
     def next_release_date() -> str:
         """Get release time as Unix EPOCH timestamp"""
         utc_time = datetime.datetime.utcnow()
         days = 1 if utc_time.hour >= 3 else 0
         offset_time = utc_time + datetime.timedelta(days=days)
-        send_timestamp = offset_time.replace(hour=3, minute=0, second=0, microsecond=0, tzinfo=datetime.timezone.utc).timestamp()
+        send_timestamp = offset_time.replace(hour=3, minute=0, second=0, microsecond=0,
+                                             tzinfo=datetime.timezone.utc).timestamp()
         return str(send_timestamp)

--- a/emoji_message.py
+++ b/emoji_message.py
@@ -56,11 +56,11 @@ class EmojiMessage:
         }
 
     @staticmethod
-    def next_release_date() -> str:
+    def next_release_date(release_hour: int = 3) -> str:
         """Get release time as Unix EPOCH timestamp"""
         utc_time = datetime.datetime.utcnow()
-        days = 1 if utc_time.hour >= 3 else 0
-        offset_time = utc_time + datetime.timedelta(days=days)
-        send_timestamp = offset_time.replace(hour=3, minute=0, second=0, microsecond=0,
-                                             tzinfo=datetime.timezone.utc).timestamp()
+        if utc_time.hour >= release_hour:
+            utc_time += datetime.timedelta(days=1)
+        send_timestamp = utc_time.replace(hour=release_hour, minute=0, second=0, microsecond=0,
+                                          tzinfo=datetime.timezone.utc).timestamp()
         return str(send_timestamp)


### PR DESCRIPTION
Resolves #13 

### Description

Add scheduled message to emoji event callback, reporting emoji changes to a public channel daily.

### Acceptance Criteria

 - [x] Emoji messages are posted immediately in admin channel
 - [x] The same emoji message is scheduled to post to emoji_meta channel and appears at 3 am UTC 

### Testing

1. Pull this branch
1. (Optional) If you don't want to pay attention at 3 UTC you can change the release_hour to better fit your schedule
1. Start the application
```bash
SLACK_BOT_TOKEN=<integration_testing_api_key>
export SLACK_BOT_TOKEN
python app.py
```
1. Create a new emoji (or several), delete, add an alias
1. Ensure automod sends a message about each emoji event immediately to the admin channel
1. Ensure automod sends a message about all of the emoji events to the emoji_meta channel at the scheduled time
