### PR TITLE
New channel reporting to the admin channel

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,9 @@
 
 import os
 import slack
+
 from emoji_message import EmojiMessage
+from new_channel_message import NewChannelMessage
 
 
 @slack.RTMClient.run_on(event='emoji_changed')
@@ -12,23 +14,47 @@ def emoji_callback(**payload):
     Triggered when an emoji is added, removed, or when a new alias has been created.
     """
     web_client = payload['web_client']
-
     event_type = payload['data']['subtype']
     emoji_name = payload['data']['name'] if event_type == 'add' else payload['data']['names'][0]
 
     send_emoji_message(web_client, 'admin', emoji_name, event_type)
 
 
-def send_emoji_message(web_client: slack.WebClient, channel: str, emoji_name: str, event_type: str):
+@slack.RTMClient.run_on(event='channel_created')
+def new_channel_callback(**payload):
+    """Catch channel_created event.
+
+    Triggered when a channel has been created.
+    """
+    web_client = payload['web_client']
+    new_channel_name = payload['data']['channel']['name']
+
+    send_new_channel_message(web_client, 'admin', new_channel_name)
+
+
+def send_emoji_message(web_client: slack.WebClient, report_channel: str, emoji_name: str, event_type: str):
     """Send a message to a channel about an emoji event.
 
     :param web_client: The client to respond on
-    :param channel: The channel to send the message to
+    :param report_channel: The channel to send the message to
     :param emoji_name: The name of the emoji
     :param event_type: The event that has happened, 'add' or 'remove'
     """
-    emoji_message = EmojiMessage(channel, emoji_name, event_type)
+    emoji_message = EmojiMessage(report_channel, emoji_name, event_type)
     message = emoji_message.get_message_payload()
+
+    web_client.chat_postMessage(**message)
+
+
+def send_new_channel_message(web_client: slack.WebClient, report_channel: str, new_channel_name: str):
+    """Send a message to a channel about a new channel event.
+
+    :param web_client: The client to respond on
+    :param report_channel: The channel to send the message to
+    :param new_channel_name: The name of the created channel
+    """
+    new_channel_message = NewChannelMessage(report_channel, new_channel_name)
+    message = new_channel_message.get_message_payload()
 
     web_client.chat_postMessage(**message)
 

--- a/emoji_message.py
+++ b/emoji_message.py
@@ -4,17 +4,17 @@
 class EmojiMessage:
     """Constructs emoji report message."""
 
-    def __init__(self, channel, icon_emoji, event_type):
+    def __init__(self, report_channel, icon_emoji, event_type):
         """Initialize EmojiMessage.
 
         Created with the channel to send the message to, the event type that triggered the callback and the emoji to
         report on.
 
-        :param channel: The channel to send the emoji message to
+        :param report_channel: The channel to send the emoji message to
         :param icon_emoji: The name of the emoji
         :param event_type: The event that has happened, 'add' or 'remove'
         """
-        self.channel = channel
+        self.report_channel = report_channel
         self.username = 'automod'
         self.icon_emoji = icon_emoji
         self.event_type = event_type
@@ -27,7 +27,7 @@ class EmojiMessage:
         """
         return {
             'ts': self.timestamp,
-            'channel': self.channel,
+            'channel': self.report_channel,
             'username': self.username,
             'icon_emoji': self.icon_emoji,
             'blocks': [self._get_message_block()],

--- a/new_channel_message.py
+++ b/new_channel_message.py
@@ -1,0 +1,38 @@
+"""Constructs new channel report message."""
+
+
+class NewChannelMessage:
+    """Constructs new channel report message."""
+
+    def __init__(self, report_channel, new_channel):
+        """Initialize NewChannelMessage.
+
+        Created with the channel to send the message to and the channel that was created
+        :param report_channel: The channel to send the new channel message to
+        :param new_channel: The name of the newly created channel
+        :param event_type: The event that has happened, 'add' or 'remove'
+        """
+        self.report_channel = report_channel
+        self.username = 'automod'
+        self.new_channel = new_channel
+        self.timestamp = ''
+
+    def get_message_payload(self) -> dict:
+        """Format and returns information to post slack message.
+
+        :return: Formatted information for slack
+        """
+        return {
+            'ts': self.timestamp,
+            'channel': self.report_channel,
+            'username': self.username,
+            'text': self._get_message_text(),
+            'link_names': True,
+        }
+
+    def _get_message_text(self) -> str:
+        """Create and returns formatted message text to send.
+
+        :return: Formatted message text
+        """
+        return f'The channel #{self.new_channel} has been created'


### PR DESCRIPTION
Resolves #15 

## Description
Listens to new channel events and reports them to the admin channel

## Acceptance  criteria
- [ ] Automod is subscribed to new_channel events
- [ ] Automod sends a message to the admin channel any time a new channel is created

## Testing
1. Pull this branch
1. Start the application
```bash
SLACK_BOT_TOKEN=<integration_testing_api_key>
export SLACK_BOT_TOKEN
python app.py
```
1. Create a new channel
1. Ensure automod sends a message about the new channel to the admin channel