### PR TITLE
Send new user message to the admin_logs channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ AutoMod
     ```bash
     pip install -Ur requirements.txt
     ```
-* Run app (after activating venv)
+* Run app (after activating venv). API key should be the "Bot User OAuth Token" under the Oauth &
+  Permissions tab
     ```bash
     SLACK_BOT_TOKEN=<production_api_key>
     export SLACK_BOT_TOKEN

--- a/app.py
+++ b/app.py
@@ -96,6 +96,7 @@ def send_new_channel_message(web_client: slack.WebClient, report_channel: str, n
 
     web_client.chat_postMessage(**message)
 
+
 def send_new_user_message(web_client: slack.WebClient, report_channel: str, new_user: str) -> None:
     """Send a message to a channel about a new channel event.
 

--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def send_new_channel_message(web_client: slack.WebClient, report_channel: str, n
 
 
 def send_new_user_message(web_client: slack.WebClient, report_channel: str, new_user: str) -> None:
-    """Send a message to a channel about a new channel event.
+    """Send a message to a channel about a new user event. Automatically pins the message.
 
     :param web_client: The client to respond on
     :param report_channel: The channel to send the message to
@@ -107,7 +107,10 @@ def send_new_user_message(web_client: slack.WebClient, report_channel: str, new_
     new_user_message = NewUserMessage(report_channel, new_user)
     message = new_user_message.get_message_payload()
 
-    web_client.chat_postMessage(**message)
+    response = web_client.chat_postMessage(**message)
+
+    # Pin this message to the channel
+    web_client.pins_add(channel=response['channel'], timestamp=response['ts'])
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from time import sleep
 
 from emoji_message import EmojiMessage
 from new_channel_message import NewChannelMessage
+from new_user_message import NewUserMessage
 
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,18 @@ def new_channel_callback(**payload) -> None:
     new_channel_name = payload['data']['channel']['name']
 
     send_new_channel_message(web_client, 'admin', new_channel_name)
+
+
+@slack.RTMClient.run_on(event='team_join')
+def new_user_callback(**payload) -> None:
+    """Catch team_join event.
+
+    Triggered when a user has joined the workspace.
+    """
+    web_client = payload['web_client']
+    new_user = payload['data']['user']
+
+    send_new_user_message(web_client, 'admin_logs', new_user)
 
 
 def send_emoji_message(web_client: slack.WebClient, report_channel: str, emoji_name: str, event_type: str) -> None:
@@ -83,6 +96,17 @@ def send_new_channel_message(web_client: slack.WebClient, report_channel: str, n
 
     web_client.chat_postMessage(**message)
 
+def send_new_user_message(web_client: slack.WebClient, report_channel: str, new_user: str) -> None:
+    """Send a message to a channel about a new channel event.
+
+    :param web_client: The client to respond on
+    :param report_channel: The channel to send the message to
+    :param new_user: The new slack user object
+    """
+    new_user_message = NewUserMessage(report_channel, new_user)
+    message = new_user_message.get_message_payload()
+
+    web_client.chat_postMessage(**message)
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,

--- a/new_user_message.py
+++ b/new_user_message.py
@@ -1,5 +1,6 @@
 """Constructs user report message."""
 
+
 class NewUserMessage:
     """Constructs user report message."""
 

--- a/new_user_message.py
+++ b/new_user_message.py
@@ -1,0 +1,45 @@
+"""Constructs user report message."""
+
+class NewUserMessage:
+    """Constructs user report message."""
+
+    def __init__(self, report_channel, new_user):
+        """Initialize UserMessage.
+
+        Created with the channel to send the message to and the new.
+
+        :param report_channel: The channel to send the user message to
+        :param user: The new user
+        """
+        self.report_channel = report_channel
+        self.username = 'automod'
+        self.new_user_id = new_user['id']
+        self.new_user_display_name = new_user['name']
+        self.new_user_real_name = new_user['real_name']
+        self.new_user_email = new_user['profile']['email']
+        self.timestamp = ''
+
+    def get_message_payload(self) -> dict:
+        """Format and returns information to post slack message.
+
+        :return: Formatted information for slack
+        """
+        return {
+            'ts': self.timestamp,
+            'channel': self.report_channel,
+            'username': self.username,
+            'text': self._get_message_text(),
+            'link_names': True,
+        }
+
+    def _get_message_text(self) -> str:
+        """Create and returns formatted message text to send.
+
+        :return: Formatted message text
+        """
+        return (
+            f'New user has joined the workspace: @{self.new_user_display_name}\n'
+            f'Email: {self.new_user_email}\n'
+            f'Full Name: {self.new_user_real_name}\n'
+            f'UID: {self.new_user_id}'
+        )


### PR DESCRIPTION
Closes #32 

## Description
Adds a new subscription to team_join events. Crafts a message with some basic user info and sends it to the admin_logs channel. Automod then automatically pins this message to the channel.

### Screenshots
<img width="470" alt="Screen Shot 2021-12-18 at 3 16 18 PM" src="https://user-images.githubusercontent.com/13680789/146654512-585a84b1-4660-47b0-8160-a112cfaa703e.png">

## AC
- [ ] When a new user joins the workspace, send a message to the admin channel with the user's name, id, email, and mention
- [ ] Pin this message to the channel so it doesn't get eaten by the message limit

## Testing
### Initial setup
1. Clone this repository and check out this branch
    ```bash
    git clone git@github.com:OSU-CS/automod.git
    git checkout hts/new-user-message
    ```
2. Install python3.7 and pip
3. Create base venv (virtual environment)
    ```bash
    pip install virtualenv
    virtualenv -p `which python3.7` venv
    ```
4. Activate venv
    ```bash
    source venv/bin/activate
    ```
5. Rebuild venv with dependencies
    ```bash
    pip install -Ur requirements.txt
    ```
6. Run app (after activating venv). (Ask hunter)
    ```bash
    SLACK_BOT_TOKEN=<intergration_oauth_key>
    export SLACK_BOT_TOKEN
    python app.py
    ```
### Testing functionality
1. Ask Hunter for an invite to the integration testing slack workspace and an invite to the `admin_logs` channel
2. Sign up for this workspace
3. Confirm message was sent with the correct information
4. Confirm this message was pinned
5. Change your display name
6. Confirm it was updated in the mention of the message